### PR TITLE
Add force-invokers to payload injection button

### DIFF
--- a/Patches/UIPatches.cs
+++ b/Patches/UIPatches.cs
@@ -95,8 +95,18 @@ namespace HoloCheck.Patches
                 changePasskeyButton.GetComponent<Button>().onClick.AddListener(ChangePasskeyButton);
                 injectorButton.GetComponent<Button>().onClick.AddListener(InjectorButtonPressed);
 
-                injectorButton.GetComponent<Image>().color = Color.white;
-                injectorText.GetComponent<TextMeshProUGUI>().text = "Payload Injection disabled";
+
+                if (HoloCheck.payloadInjection)
+                {
+                    injectorButton.GetComponent<Image>().color = Color.green;
+                    injectorText.GetComponent<TextMeshProUGUI>().text = "Payload Injection enabled";
+                }
+                else
+                {
+                    injectorButton.GetComponent<Image>().color = Color.white;
+                    injectorText.GetComponent<TextMeshProUGUI>().text = "Payload Injection disabled";
+                }
+                
 
                 // Debugging stuff
                 //EnableHoloCheckSettingsPanel();
@@ -117,11 +127,15 @@ namespace HoloCheck.Patches
             if (HoloCheck.payloadInjection)
             {
                 injectorButton.GetComponent<Image>().color = Color.green;
+                //Invoke VersionPatches here with no passkey to reset the version number.
+                VersionPatches.ResetVersionNumber();
                 injectorText.GetComponent<TextMeshProUGUI>().text = "Payload Injection enabled";
             }
             else
             {
                 injectorButton.GetComponent<Image>().color = Color.white;
+                //Forcefully invoke VersionPatches here to ensure that user enters with a modified version number.
+                VersionPatches.ChangePasskey(HoloCheck.passkey);
                 injectorText.GetComponent<TextMeshProUGUI>().text = "Payload Injection disabled";
 
             }

--- a/Patches/VersionPatches.cs
+++ b/Patches/VersionPatches.cs
@@ -37,6 +37,20 @@ namespace HoloCheck.Patches
                 ChangeVersionWithPasskey(passkey, instance);
             }
         }
+
+        public static void ResetVersionNumber()
+        {
+            if (instance.gameVersionNum != HoloCheck.originalVersion)
+            {
+                instance.gameVersionNum = HoloCheck.originalVersion;
+                HoloCheck.Logger.LogInfo("Resetting the version back to the original number.");
+                HoloCheck.Logger.LogInfo("The new version is = " + instance.gameVersionNum.ToString());
+            }
+            else
+            {
+                HoloCheck.Logger.LogWarning("Detected version matches the target version! ");
+            }
+        }
         private static void ChangeVersionWithPasskey(string passkey, GameNetworkManager __instance)
         {
             HoloCheck.Logger.LogInfo("VersionPatches awoken!");


### PR DESCRIPTION
Added function to VersionPatches to reset the version number back to the original number.
Added calls to VersionPatches ChangePasskey and ResetVersionNumber in the Injector Button's code, to forcefully change/reset the passkey when the button is pressed. 
i.e. On activation of Payload Injection, the version number is immediately set to original.
On deactivation of payload injection, the version number is immediately set to the variant with the injected passkey.